### PR TITLE
Add tag prop to render non-span html elements

### DIFF
--- a/src/Pluralize.js
+++ b/src/Pluralize.js
@@ -7,32 +7,33 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { pluralize } from './utils';
 
-const Plural = ({ className, style, ...props }) =>
-  textOnly ? (
-    pluralize(props)
-  ) : (
-    <span className={className} style={style}>
+
+const Plural = ({ className, style, tag: Tag, ...props }) =>
+  Tag ? (
+    <Tag className={className} style={style}>
       {pluralize(props)}
-    </span>
+    </Tag>
+  ) : (
+    pluralize(props)
   );
 
 Plural.propTypes = {
-  singular: PropTypes.string.isRequired,
-  plural: PropTypes.string,
-  count: PropTypes.number,
-  showCount: PropTypes.bool,
-  textOnly: PropTypes.bool,
   className: PropTypes.string,
+  count: PropTypes.number,
+  plural: PropTypes.string,
+  showCount: PropTypes.bool,
+  singular: PropTypes.string.isRequired,
   style: PropTypes.object,
+  tag: PropTypes.string,
   zero: PropTypes.string
 };
 
 Plural.defaultProps = {
+  className: null,
   count: 1,
   showCount: true,
-  textOny: false,
-  className: null,
-  style: {},
+  style: null,
+  tag: 'span',
   zero: null
 };
 

--- a/src/Pluralize.js
+++ b/src/Pluralize.js
@@ -3,32 +3,37 @@
  * Tom Smith (https://github.com/tsmith123)
  */
 
-import React from 'react'
-import PropTypes from 'prop-types'
-import { pluralize } from './utils'
+import React from 'react';
+import PropTypes from 'prop-types';
+import { pluralize } from './utils';
 
-const Plural = ({ className, style, ...props }) => (
-  <span className={className} style={style}>
-    {pluralize(props)}
-  </span>
-)
+const Plural = ({ className, style, ...props }) =>
+  textOnly ? (
+    pluralize(props)
+  ) : (
+    <span className={className} style={style}>
+      {pluralize(props)}
+    </span>
+  );
 
 Plural.propTypes = {
   singular: PropTypes.string.isRequired,
   plural: PropTypes.string,
   count: PropTypes.number,
   showCount: PropTypes.bool,
+  textOnly: PropTypes.bool,
   className: PropTypes.string,
   style: PropTypes.object,
   zero: PropTypes.string
-}
+};
 
 Plural.defaultProps = {
   count: 1,
   showCount: true,
+  textOny: false,
   className: null,
   style: {},
   zero: null
-}
+};
 
-export default Plural
+export default Plural;


### PR DESCRIPTION
This PR creates a prop `tag`, which adds the ability to define the type of HTML element to render. Alternatively, by making the prop `falsy`, the component can render text-only. 

In my case, I'm using the `<Pluralize />` component in a SVG `text` tag, which doesn't accept `span` as a child element. With this change, I can either use an acceptable `a` tag or no element at all.

Note: `span` is still used by default so this shouldn't affect current users.

